### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kei10in/takaneko/security/code-scanning/4](https://github.com/kei10in/takaneko/security/code-scanning/4)

To fix this issue, you should add an explicit `permissions` block to the workflow (at the root level or for the individual job). Since the job(s) in this workflow only check out source code, install dependencies, and run tests/builds (with no evidence of writing to the repo, creating issues, or interacting with pull requests), the minimal recommended permission is `contents: read`. This can be added either just above the `jobs:` block (affecting all jobs), or inside the `build` job block for more granular control. The single best way without changing functionality is to add the following at the root (lines 9-10):

```yaml
permissions:
  contents: read
```

No imports or additional dependencies are needed—just the change to the yaml file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
